### PR TITLE
Save some more KBs

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+/:static/*
+  Cache-Control: public, max-age=2600000
+  Access-Control-Allow-Origin: *

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,7 +7,7 @@ module.exports = {
   configureWebpack: {
     optimization: {
       splitChunks: {
-        maxSize: 500000
+        maxSize: 1000000
       }
     },
     plugins: [

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,15 +1,27 @@
 // var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const path = require('path')
 const webpack = require('webpack')
 
 module.exports = {
   lintOnSave: false,
   configureWebpack: {
-  	plugins: [
-  		// new BundleAnalyzerPlugin(),
-  		new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
-  	],
+    // optimization: {
+    //   splitChunks: {
+    //     maxSize: 500000
+    //   }
+    // },
+    plugins: [
+      // new BundleAnalyzerPlugin(),
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
+    ],
     output: {
       globalObject: 'this'
+    },
+    resolve: {
+      alias: {
+        "bn.js": path.resolve(__dirname, 'node_modules/bn.js'),
+        "underscore": path.resolve(__dirname, 'node_modules/underscore')
+      }
     }
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,11 +5,11 @@ const webpack = require('webpack')
 module.exports = {
   lintOnSave: false,
   configureWebpack: {
-    // optimization: {
-    //   splitChunks: {
-    //     maxSize: 500000
-    //   }
-    // },
+    optimization: {
+      splitChunks: {
+        maxSize: 500000
+      }
+    },
     plugins: [
       // new BundleAnalyzerPlugin(),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)


### PR DESCRIPTION
Saves around 400kb (~100kb gzipped) by aliasing `bn.js` and `underscore` to the same version (they were being loaded multiple times).

By `optimization.splitChunks.maxSize` in the Webpack config we can also split the vendors file into smaller bits, might improve things over HTTP/2?