### PR TITLE
Album Editors (UI)

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1043,7 +1043,7 @@ export default {
         console.log(err)
         dispatch('selfDestructMsg', {
           type: 'error',
-          msg: err.message
+          msg: err.response.data || err.message
         })
         if ('response' in err) {
           if (err.response.status === 401) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1023,28 +1023,31 @@ export default {
       return Promise.reject(new Error('Missing album'))
     }
     if (!(await dispatch('checkWeb3'))) throw new Error('Transaction Failed')
-    return axios.put(getters.baseURL('/albums/' + album.id), {albumName: album.name, clovers: album.clovers}, {
+    return axios.put(getters.baseURL('/albums/' + album.id), {albumName: album.name, ...album}, {
       headers: {
         Authorization: getters.authHeader
       }
     })
       .then(({data}) => {
         if (!data) throw new Error('404')
-        let setAlbum
         if (state.currentAlbum && state.currentAlbum.id === album.id) {
-          setAlbum = JSON.parse(JSON.stringify(state.currentAlbum))
-        } else {
-          setAlbum = state.allAlbums.find(a => a.id === album.id)
+          commit('SET_CURRENT_ALBUM', data)
         }
-        if (setAlbum) {
-          setAlbum.name = data.name
-          setAlbum.clovers = data.clovers
-          setAlbum.modified = data.modified
-          commit('SET_CURRENT_ALBUM', setAlbum)
-        }
+        // let setAlbum
+        // if (state.currentAlbum && state.currentAlbum.id === album.id) {
+        //   setAlbum = JSON.parse(JSON.stringify(state.currentAlbum))
+        // } else {
+        //   setAlbum = state.allAlbums.find(a => a.id === album.id)
+        // }
+        // if (setAlbum) {
+        //   setAlbum.name = data.name
+        //   setAlbum.clovers = data.clovers
+        //   setAlbum.modified = data.modified
+        //   commit('SET_CURRENT_ALBUM', setAlbum)
+        // }
         dispatch('selfDestructMsg', {
           type: 'success',
-          msg: 'Album details updated'
+          msg: 'Album updated'
         })
       })
       .catch(err => {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1030,21 +1030,10 @@ export default {
     })
       .then(({data}) => {
         if (!data) throw new Error('404')
+        // update current ?
         if (state.currentAlbum && state.currentAlbum.id === album.id) {
           commit('SET_CURRENT_ALBUM', data)
         }
-        // let setAlbum
-        // if (state.currentAlbum && state.currentAlbum.id === album.id) {
-        //   setAlbum = JSON.parse(JSON.stringify(state.currentAlbum))
-        // } else {
-        //   setAlbum = state.allAlbums.find(a => a.id === album.id)
-        // }
-        // if (setAlbum) {
-        //   setAlbum.name = data.name
-        //   setAlbum.clovers = data.clovers
-        //   setAlbum.modified = data.modified
-        //   commit('SET_CURRENT_ALBUM', setAlbum)
-        // }
         dispatch('selfDestructMsg', {
           type: 'success',
           msg: 'Album updated'

--- a/src/style/helpers.css
+++ b/src/style/helpers.css
@@ -167,7 +167,11 @@
   .hover-bg-l-green {
     transition: all var(--anim-timing-medium);
     &:hover, &:active { background-color: var(--lightest-green); }
-  }  
+  }
+  .hover-bg-m-green {
+    transition: all var(--anim-timing-medium);
+    &:hover, &:active { background-color: var(--lighter-green); }
+  }
   .hover-bg-l-red{
     transition: all var(--anim-timing-medium);
     &:hover, &:active { background-color: var(--lightest-red); }

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ export function cloverIsMonochrome (clover) {
 }
 
 export function abbrvAddr (addr) {
-  return addr.substr(0, 6) + '..' + addr.slice(-4)
+  return addr.substr(0, 6) + '...' + addr.slice(-4)
 }
 
 export function cleanObj (o) {

--- a/src/views/Album.vue
+++ b/src/views/Album.vue
@@ -46,7 +46,8 @@
               li.my1.relative.rounded(v-for="editor in album.editorsData")
                 router-link.block.py2.bg-lightest-green.rounded.truncate.lh2.hover-bg-m-green(:to="{name: 'User', params: {addr: editor.address}}")
                   | {{editor.name}}
-                button.absolute.top-0.right-0.h-100.px2.flex.items-center.justify-center.pointer(aria-label="Remove Editor")
+                //- rmv btn
+                button.absolute.top-0.right-0.h-100.px2.flex.items-center.justify-center.pointer(aria-label="Remove Editor", @click="removeEditor(editor)")
                   svg-x(style="width:1rem;height:1rem")
             //- add
             form.my1(v-if="isOwner && editors.length < 4", @submit.prevent="addEditor")
@@ -70,6 +71,7 @@ import ClvSvg from '@/components/Clv--SVG'
 import svgX from '@/components/Icons/SVG-X'
 import {mapState, mapGetters, mapActions} from 'vuex'
 import utils from 'web3-utils'
+const clone = d => JSON.parse(JSON.stringify(d))
 export default {
   name: 'Album',
   props: ['id'],
@@ -120,7 +122,7 @@ export default {
       this.edit = true
     },
     async submitNewName () {
-      let albumCopy = JSON.parse(JSON.stringify(this.album))
+      let albumCopy = clone(this.album)
       albumCopy.name = this.newName
       await this.updateAlbum(albumCopy)
       this.edit = false
@@ -140,7 +142,7 @@ export default {
       let yes = window.confirm('Are you sure you want to remove this Clover? This action cannot be undone...')
       if (yes) {
         console.log(`DELETE ${clover}`)
-        let album = JSON.parse(JSON.stringify(this.album))
+        let album = clone(this.album)
         console.log(album.clovers)
         let cloverIndex = album.clovers.indexOf(clover)
         console.log({cloverIndex})
@@ -155,10 +157,17 @@ export default {
     },
     addEditor () {
       if (this.editors.includes(this.newEditor)) return alert('Editor already added.')
-      const album = JSON.parse(JSON.stringify(this.album))
+      const album = clone(this.album)
       album.editors = album.editors || []
       album.editors.push(this.newEditor)
       this.updateAlbum(album).then(() => { this.newEditor = '' })
+    },
+    removeEditor (editor) {
+      if (editor && confirm(`Are you sure you want to remove "${editor.name}" from editors?`)) {
+        const album = clone(this.album)
+        album.editors = album.editors.filter(ed => ed !== editor.address)
+        this.updateAlbum(album)
+      }
     }
   },
   components: { svgX, Modal, ClvSvg }

--- a/src/views/Album.vue
+++ b/src/views/Album.vue
@@ -10,7 +10,7 @@
             //- owner
             router-link.h5.mr1.mt1.inline-block.px2.py1.bg-lightest-green.rounded.border.border-transparent.hover-bg-m-green(:to="{name: 'User', params: {addr: album.userAddress}}") {{_userName}}
             //- editors
-            router-link.h5.mr1.mt1.inline-block.px2.py1.bg-lightest-green.rounded.border.border-transparent.hover-bg-m-green(v-for="addr in album.editors", :to="{name: 'User', params: {addr: addr}}") {{editorName(addr)}}
+            router-link.h5.mr1.mt1.inline-block.px2.py1.bg-lightest-green.rounded.border.border-transparent.hover-bg-m-green(v-for="addr in editors", :to="{name: 'User', params: {addr: addr}}") {{editorName(addr)}}
           h6.h5.sm-h4.flex.items-center.pt1
             | {{album.clovers && album.clovers.length}}
             img.block.ml1(src="@/assets/icons/clover-icon-1.svg", style="width:0.875em;")
@@ -42,7 +42,7 @@
           .mb3.px2.pb1
             h4.h4.font-exp.lh1.mb3 Editors
             ul.list-reset.m0
-              li.my1.relative.rounded(v-for="addr in album.editors")
+              li.my1.relative.rounded(v-for="addr in editors")
                 router-link.block.py2.bg-lightest-green.rounded.truncate.lh2.hover-bg-m-green(:to="{name: 'User', params: {addr: addr}}")
                   | {{editorName(addr)}}
                 //- rmv editor btn
@@ -170,7 +170,7 @@ export default {
       }
     },
     editorName (addr) {
-      const data = this.album.editorsData.find(ed => addr === ed.address)
+      const data = (this.album.editorsData || []).find(ed => addr === ed.address)
       return (data && data.name) || abbrvAddr(addr)
     }
   },

--- a/src/views/Album.vue
+++ b/src/views/Album.vue
@@ -8,7 +8,7 @@
           h6.col-9
             //- span.h6.sm-h5.mr2 Editor &nbsp;&rarr;
             //- owner
-            router-link.h5.mr1.mt1.inline-block.px2.py1.bg-lightest-green.rounded.border.border-transparent.hover-bg-m-green(:to="{name: 'User', params: {addr: album.userAddress}}") {{_userName}}
+            router-link.h5.mr1.mt1.inline-block.px2.py1.bg-lightest-green.rounded.border.border-transparent.hover-bg-m-green(:to="{name: 'User', params: {addr: album.userAddress}}") {{userName(album.user)}}
             //- editors
             router-link.h5.mr1.mt1.inline-block.px2.py1.bg-lightest-green.rounded.border.border-transparent.hover-bg-m-green(v-for="addr in editors", :to="{name: 'User', params: {addr: addr}}") {{editorName(addr)}}
           h6.h5.sm-h4.flex.items-center.pt1
@@ -39,7 +39,7 @@
             input.border.py2.px2.rounded.col-12.input.center(v-model="newName", name="clover-album-name", type="text", autocomplete="off", placeholder="Album Name", v-autofocus="true", required)
             button.mt3.inline-block.h4.pointer.py2.px3.rounded.bg-green.white(type="submit", :disabled="newName === album.name") Update
           //- edit editors
-          .mb3.px2.pb1
+          .mb3.px2.pb1(v-if="editorsEnabled")
             h4.h4.font-exp.lh1.mb3 Editors
             ul.list-reset.m0
               li.my1.relative.rounded(v-for="addr in editors")
@@ -52,7 +52,7 @@
             form.my1(v-if="isOwner && editors.length < 4", @submit.prevent="addEditor")
               label.hide Add Editor
               input.border-dashed.focus-border.py2.rounded.col-12.input.center(v-model="newEditor", name="clover-album-editor", type="text", autocomplete="off", placeholder="Add Editor")
-              button.mt3.inline-block.h4.pointer.py2.px3.rounded.bg-green.white(type="submit", :disabled="!validEditor", v-show="newEditor.length") Add
+              button.mt3.inline-block.h4.pointer.py2.px3.rounded.bg-green.white(type="submit", :disabled="!newEditorIsValid", v-show="newEditor.length") Add
           //- delete
           .mt4.relative.rounded.red.px2.py3(v-if="isOwner")
             .absolute.bg-red.opacity-25.overlay.rounded
@@ -97,11 +97,11 @@ export default {
     isEditor () {
       return this.isOwner || this.editors.map(ed => ed.toLowerCase()).includes(this.account)
     },
-    _userName () {
-      return this.album && this.userName(this.album.user)
-    },
-    validEditor () {
+    newEditorIsValid () {
       return utils.isAddress(this.newEditor)
+    },
+    editorsEnabled () {
+      return this.album.editorsData
     }
   },
   beforeRouteEnter (to, from, next) {

--- a/src/views/Album.vue
+++ b/src/views/Album.vue
@@ -15,7 +15,7 @@
             | {{album.clovers && album.clovers.length}}
             img.block.ml1(src="@/assets/icons/clover-icon-1.svg", style="width:0.875em;")
         //- edit btn
-        button.absolute.top-0.right-0.p2.block.h4.pointer(v-if="isEditor", @click="showEdit" style="transform:scale(-1, 1)", aria-label="Edit Album") ✎
+        button.absolute.top-0.right-0.p2.block.h4.pointer(v-if="isOwner", @click="showEdit" style="transform:scale(-1, 1)", aria-label="Edit Album") ✎
     //- clovers
     section.px1.flex.flex-wrap
       //- item


### PR DESCRIPTION
UI updates for Album Editors feature
- Requires API update [PR#11](https://github.com/clovers-network/clovers-api/pull/11)

Album header includes editors:
<img width="836" alt="Screenshot 2020-05-05 16 11 08" src="https://user-images.githubusercontent.com/6071219/81077232-ff027a80-8eec-11ea-8a10-5674646a789c.png">

Album owner can add/remove editors by address in the "edit" modal:
<img width="421" alt="Screenshot 2020-05-05 16 11 32" src="https://user-images.githubusercontent.com/6071219/81077246-00cc3e00-8eed-11ea-96a3-77713943a1bf.png">
