### PR TITLE
Update portis SDK to 3.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint"
   ],
   "dependencies": {
-    "@portis/web3": "^2.0.0-beta.40",
+    "@portis/web3": "3.0.10",
     "@walletconnect/web3-provider": "^1.0.0-beta.35",
     "animate.css": "^3.7.0",
     "axios": "^0.18.0",


### PR DESCRIPTION
You're using a really old version of Portis, which is why it currently doesn't work.
Plenty of performance improvements have been added to the latest SDK